### PR TITLE
Zen 4 fixes, Kernel 7.0 compile fix, aod_voltages addition

### DIFF
--- a/Linux/src/aod-voltages/aod_voltages.c
+++ b/Linux/src/aod-voltages/aod_voltages.c
@@ -361,6 +361,7 @@ static const struct {
 } aod_offset_table[] = {
     { 24, 0, 9116, 9120, 9124, 8956 },  /* Hawk Point */
     { 23, 0, 9084, 9088, 9092, 9096 },  /* Granite Ridge */
+    { 20, 0, 9096, 9100, 9104, 9108 },  /* Raphael */
     {  0, 0x1A, 9084, 9088, 9092, 9096 }, /* Zen 5 (fallback) */
     {  0, 0x19, 9084, 9088, 9092, 9096 }, /* Zen 3/4 (fallback) */
 };

--- a/Linux/src/pm_table.c
+++ b/Linux/src/pm_table.c
@@ -112,11 +112,11 @@ static const pm_family_map_t RAPHAEL_540104 = {
 /* Raphael 0x540004 (7950X/7900X 16-core, PM table 0x00540004) */
 static const pm_family_map_t RAPHAEL_540004 = {
     .named = {
-        {11, F_IOD_HOTSPOT}, {70, F_FCLK}, {74, F_UCLK}, {78, F_MCLK},
-        {82, F_VSOC}, {259, F_VDDG_IOD}, {261, F_VDDG_CCD},
-        {268, F_VDDP}, {271, F_VCORE}
+        {11, F_IOD_HOTSPOT}, {56, F_VDD_MISC}, {70, F_FCLK}, {74, F_UCLK},
+        {78, F_MCLK}, {82, F_VSOC}, {259, F_VDDG_IOD},
+        {261, F_VDDG_CCD}, {268, F_VDDP}, {271, F_VCORE}
     },
-    .named_count = 9,
+    .named_count = 10,
     .vid_idx = 275, .ppt_idx = 3, .socket_power_idx = 29,
     .core_voltage_start = 309, .core_temp_start = 325, .core_clock_start = 341,
     .max_cores = 16

--- a/Linux/src/pm_table.c
+++ b/Linux/src/pm_table.c
@@ -114,7 +114,7 @@ static const pm_family_map_t RAPHAEL_540004 = {
     .named = {
         {11, F_IOD_HOTSPOT}, {70, F_FCLK}, {74, F_UCLK}, {78, F_MCLK},
         {82, F_VSOC}, {259, F_VDDG_IOD}, {261, F_VDDG_CCD},
-        {269, F_VDDP}, {271, F_VCORE}
+        {268, F_VDDP}, {271, F_VCORE}
     },
     .named_count = 9,
     .vid_idx = 275, .ppt_idx = 3, .socket_power_idx = 29,
@@ -319,9 +319,21 @@ void pm_table_read(uint32_t version, const float *table, int count,
             out->core_temps_c[i] = table[map->core_temp_start + i];
     }
     if (map->core_voltage_start + nc <= count) {
-        out->core_voltages_count = nc;
-        for (int i = 0; i < nc; i++)
-            out->core_voltages[i] = table[map->core_voltage_start + i];
+        int out_idx = 0;
+        // Scan all possible slots, collect up to 'nc' non-zero voltages
+        for (int i = 0; i < map->max_cores; i++) {
+            if (map->core_voltage_start + i >= count) break;
+            float v = table[map->core_voltage_start + i];
+            if (v != 0.0f && out_idx < nc) {
+                out->core_voltages[out_idx++] = v;
+                if (out_idx >= nc) break;
+            }
+        }
+        // Fill the rest with zeroes
+        for (int i = out_idx; i < nc; i++) {
+            out->core_voltages[i] = 0.0f;
+        }
+        out->core_voltages_count = out_idx;
     }
 
     /* VID — always read directly from vid_idx (never in named arrays) */

--- a/Linux/src/tuxbench/tuxbench.c
+++ b/Linux/src/tuxbench/tuxbench.c
@@ -858,11 +858,7 @@ static int __init tuxbench_init(void)
     }
 
     tb_class =
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
-        class_create(THIS_MODULE, CLASS_NAME);
-#else
         class_create(CLASS_NAME);
-#endif
     if (IS_ERR(tb_class)) {
         ret = PTR_ERR(tb_class);
         pr_err("tuxbench: class_create failed: %d\n", ret);


### PR DESCRIPTION
Fix per-core voltage enumeration of Ryzen 7 7900x, as it has some registers turned off, based on the cores turned off in the voltage part of PM table, also added fix to compile on Linux kernel 7.0 to the tuxbench.c, and added voltage registers to match ones on Zen 4, based on info from ZenTimings running on Windows install on the same hardware.