### PR TITLE
Fix 2x UI scaling when elevated on Wayland HiDPI displays

### DIFF
--- a/Linux/src/main.c
+++ b/Linux/src/main.c
@@ -53,8 +53,7 @@ static void elevate_if_necessary(int argc, char **argv)
     /* Build argv for pkexec: pkexec <self> --env-VAR=VALUE ... [original args] */
     const char *env_vars[] = {
         "DISPLAY", "WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "XAUTHORITY",
-        "DBUS_SESSION_BUS_ADDRESS", "XDG_CONFIG_HOME", "HOME",
-        "AVALONIA_SCREEN_SCALE_FACTORS", NULL
+        "DBUS_SESSION_BUS_ADDRESS", "XDG_CONFIG_HOME", "HOME", NULL
     };
 
     /* Count env args */

--- a/Linux/src/ui.c
+++ b/Linux/src/ui.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <locale.h>
+#include <unistd.h>
 
 /* ── CSS theme (GitHub dark) ────────────────────────────────────────── */
 
@@ -43,6 +44,25 @@ static void load_css(void)
         GTK_STYLE_PROVIDER(provider),
         GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     g_object_unref(provider);
+}
+
+/* ── HiDPI fix for running elevated via pkexec ──────────────────────────
+ * The app re-execs itself as root (see main.c). As root, GTK cannot read
+ * the user's desktop settings — dconf and the settings portal are per-user
+ * — so on the Wayland backend it falls back to the X server's *scaled*
+ * Xft.dpi (e.g. 192 dpi on a 200% display). But the Wayland compositor
+ * ALSO applies the per-output scale factor, so everything ends up rendered
+ * at double size. On Wayland HiDPI is conveyed solely through the output
+ * scale factor, so the font DPI must be the unscaled default: reset
+ * gtk-xft-dpi to -1 to undo the doubling while keeping the crisp 2x scale.
+ * Only the Wayland backend is affected — on X11 the scaled Xft.dpi is the
+ * legitimate HiDPI mechanism and must be left alone. */
+static void fix_elevated_wayland_dpi(void)
+{
+    if (geteuid() != 0) return;
+    GdkDisplay *display = gdk_display_get_default();
+    if (display && g_strcmp0(G_OBJECT_TYPE_NAME(display), "GdkWaylandDisplay") == 0)
+        g_object_set(gtk_settings_get_default(), "gtk-xft-dpi", -1, NULL);
 }
 
 /* ── Helpers ────────────────────────────────────────────────────────── */
@@ -830,6 +850,9 @@ static void on_activate(GtkApplication *app, gpointer user_data)
     setlocale(LC_NUMERIC, "C");
 
     load_css();
+
+    /* Undo the font-DPI doubling that occurs when elevated on Wayland */
+    fix_elevated_wayland_dpi();
 
     /* Window */
     w->window = gtk_application_window_new(app);


### PR DESCRIPTION
TuxTimings re-execs itself as root via pkexec to read SMN/PM-table registers. As root, GTK can't read the user's per-user desktop settings (dconf/settings portal), so on the Wayland backend it falls back to the X server's *scaled* Xft.dpi (e.g. 192 dpi at 200%) instead of the unscaled 96 dpi. The Wayland compositor already applies the per-output scale factor, so fonts render at double size and the whole text-sized UI comes out 2x too large.

Reset gtk-xft-dpi to GTK's unscaled default (-1) when running elevated on the Wayland backend. This undoes the doubling while keeping the compositor's crisp 2x scale. Scoped to Wayland only: on genuine X11 HiDPI sessions the scaled Xft.dpi is the legitimate mechanism and must be left alone. Backend is detected by display type name so no extra gtk4-wayland build dependency is needed.

Also drop the stale AVALONIA_SCREEN_SCALE_FACTORS entry from the pkexec env-forwarding list (leftover from an earlier Avalonia port).

Fixes #7